### PR TITLE
Blog app: add authorization rules

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'rails', '~> 7.0.3'
 
 gem 'bootstrap', '~> 5.1.3'
 gem 'bootstrap_form', '~> 5.1'
+gem 'cancancan'
 gem 'devise'
 gem 'jquery-rails'
 gem 'sassc-rails', '>= 2.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
       actionpack (>= 5.2)
       activemodel (>= 5.2)
     builder (3.2.4)
+    cancancan (3.4.0)
     capybara (3.37.1)
       addressable
       matrix
@@ -310,6 +311,7 @@ DEPENDENCIES
   bootsnap
   bootstrap (~> 5.1.3)
   bootstrap_form (~> 5.1)
+  cancancan
   capybara
   database_cleaner
   debug

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,6 @@
 class CommentsController < ApplicationController
+  load_and_authorize_resource
+
   def create
     @comment = current_user.comments.new(comment_params)
     @comment.post_id = params[:post_id]
@@ -9,12 +11,6 @@ class CommentsController < ApplicationController
     end
   end
 
-  private
-
-  def comment_params
-    params.require(:comment).permit(:text)
-  end
-
   def destroy
     @comment = Comment.find(params[:comment_id])
     @post = Post.find(@comment.post_id)
@@ -23,5 +19,11 @@ class CommentsController < ApplicationController
     @post.save
     flash[:success] = 'You have deleted this comment successfully!'
     redirect_to user_post_path(current_user.id, @comment.post_id)
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:text)
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -14,4 +14,14 @@ class CommentsController < ApplicationController
   def comment_params
     params.require(:comment).permit(:text)
   end
+
+  def destroy
+    @comment = Comment.find(params[:comment_id])
+    @post = Post.find(@comment.post_id)
+    @post.comments_counter -= 1
+    @comment.destroy!
+    @post.save
+    flash[:success] = 'You have deleted this comment successfully!'
+    redirect_to user_post_path(current_user.id, @comment.post_id)
+  end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -32,12 +32,11 @@ class PostsController < ApplicationController
 
   def destroy
     post = Post.find(params[:id])
-    # user = User.find(post.author_id)
-    # user.posts_counter -= 1
+    user = User.find(post.author_id)
+    user.posts_counter -= 1
     post.destroy
-    # user.save
+    user.save
     flash[:success] = 'You have deleted this post successfully!'
-    # redirect_to user_path(current_user.id)
-    authorize! :destroy, @post
+    redirect_to user_path(current_user.id)
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,13 +1,19 @@
 class PostsController < ApplicationController
+  load_and_authorize_resource
+
   def index
     @user = User.find(params[:user_id])
     @post = Post.includes(:user).where(user_id: @user.id).order(created_at: :desc)
   end
 
   def create
-    @post = current_user.posts.new(post_params)
-    @post.comments_counter = 0
-    @post.likes_counter = 0
+    # @post = Post.new(post_params)
+    # @post.comments_counter = 0
+    # @post.likes_counter = 0
+    @current_user = User.find(params[:user_id])
+    @post = Post.new(author: current_user, title: params[:post][:title], text: params[:post][:text],
+                     comments_counter: 0, likes_counter: 0)
+
     if @post.save
       redirect_to "/users/#{@post.author.id}/posts/#{@post.id}"
     else
@@ -38,5 +44,18 @@ class PostsController < ApplicationController
     user.save
     flash[:success] = 'You have deleted this post successfully!'
     redirect_to user_path(current_user.id)
+  end
+
+  def all_posts
+    @post = Post.all
+  end
+
+  private
+
+  def user_post_helper
+    user = User.find(params[:user_id])
+    post = Post.find(params[:post_id])
+
+    [user, post]
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -32,12 +32,12 @@ class PostsController < ApplicationController
 
   def destroy
     post = Post.find(params[:id])
-    user = User.find(post.user_id)
-    user.posts_counter -= 1
+    # user = User.find(post.author_id)
+    # user.posts_counter -= 1
     post.destroy
-    user.save
+    # user.save
     flash[:success] = 'You have deleted this post successfully!'
-    redirect_to user_path(current_user.id)
+    # redirect_to user_path(current_user.id)
     authorize! :destroy, @post
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -29,4 +29,15 @@ class PostsController < ApplicationController
   def post_params
     params.require(:post).permit(:title, :text)
   end
+
+  def destroy
+    post = Post.find(params[:id])
+    user = User.find(post.user_id)
+    user.posts_counter -= 1
+    post.destroy
+    user.save
+    flash[:success] = 'You have deleted this post successfully!'
+    redirect_to user_path(current_user.id)
+    authorize! :destroy, @post
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
   def index
     @users = User.all
-    # @current_user = current_user
+    @user = current_user
   end
 
   def show

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,3 @@
+class Ability
+  include CanCan::Ability
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,3 +1,16 @@
 class Ability
   include CanCan::Ability
+
+  def initialize(user)
+    user ||= User.new
+    can :read, Post, public: true
+    return unless user.present? # additional permissions for logged in users (they can read their own posts)
+
+    can :read, Post, user: user
+    can :manage, Post, user: user # only post owners can manage posts
+    can :manage, Comment, user: user # only post owners can manage posts
+    return unless user.admin? # additional permissions for administrators
+
+    can :manage, :all
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,9 +6,9 @@ class Ability
     can :read, Post, public: true
     return unless user.present? # additional permissions for logged in users (they can read their own posts)
 
-    can :read, Post, user: user
-    can :manage, Post, user: user # only post owners can manage posts
-    can :manage, Comment, user: user # only post owners can manage posts
+    can :read, User
+    can :manage, Post, author_id: user.id # only post owners can manage posts
+    can :manage, Comment, author_id: user.id # only post owners can manage posts
     return unless user.admin? # additional permissions for administrators
 
     can :manage, :all

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,7 +6,11 @@ class Ability
     can :read, Post, public: true
     return unless user.present? # additional permissions for logged in users (they can read their own posts)
 
-    can :read, User
+    can :read, User # all users can view users
+    can :read, Post # all users can view posts
+    can :read, Comment # all users can view comments
+    return unless user.present?
+
     can :manage, Post, author_id: user.id # only post owners can manage posts
     can :manage, Comment, author_id: user.id # only post owners can manage posts
     return unless user.admin? # additional permissions for administrators

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -5,6 +5,7 @@ class Comment < ApplicationRecord
   validates :text, presence: true, length: { in: 3..250 }
 
   after_save :update_comments_counter
+  after_destroy :update_comments_counter
 
   def update_comments_counter
     post.increment!(:comments_counter)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,7 @@
 class Post < ApplicationRecord
   belongs_to :author, class_name: 'User', foreign_key: :author_id
-  has_many :comments, foreign_key: :post_id, dependent: :destroy
-  has_many :likes, foreign_key: :post_id, dependent: :destroy
+  has_many :comments, dependent: :destroy
+  has_many :likes, dependent: :destroy
 
   validates :title, presence: true
   validates :title, length: { maximum: 250 }
@@ -9,6 +9,7 @@ class Post < ApplicationRecord
   validates :likes_counter, comparison: { greater_than_or_equal_to: 0 }
 
   after_save :update_posts_counter
+  after_destroy :update_posts_counter
 
   def update_posts_counter
     author.increment!(:posts_counter)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,7 @@
 class Post < ApplicationRecord
   belongs_to :author, class_name: 'User', foreign_key: :author_id
-  has_many :comments, foreign_key: :post_id
-  has_many :likes, foreign_key: :post_id
+  has_many :comments, foreign_key: :post_id, dependent: :destroy
+  has_many :likes, foreign_key: :post_id, dependent: :destroy
 
   validates :title, presence: true
   validates :title, length: { maximum: 250 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,4 +13,8 @@ class User < ApplicationRecord
   def last_three_posts
     posts.order(created_at: :desc).limit(3)
   end
+
+  def admin?
+    :role == 'admin'
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,12 +3,16 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable
-  has_many :posts, foreign_key: :author_id
-  has_many :comments, foreign_key: :author_id
-  has_many :likes, foreign_key: :author_id
+  has_many :posts, foreign_key: :author_id, dependent: :destroy
+  has_many :comments, foreign_key: :author_id, dependent: :destroy
+  has_many :likes, foreign_key: :author_id, dependent: :destroy
 
   validates :name, presence: true
   validates :posts_counter, comparison: { greater_than_or_equal_to: 0 }
+
+  def is?(requested_role)
+    role == requested_role.to_s
+  end
 
   def last_three_posts
     posts.order(created_at: :desc).limit(3)

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -14,4 +14,7 @@
      <p><%= comment.author.name %>: <%=comment.text%></p>
     <%end%>
   </div>
+   <% if can? :destroy, @post %>
+    <%= button_to 'Delete Post', "/users/#{params[:user_id]}/posts/#{@post.id}",  data: { "turbo-method": :delete , "turbo-confirm": "Are you sure?" }, class: "btn text-dark btn-danger" %>
+  <% end %> 
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -15,6 +15,6 @@
     <%end%>
   </div>
    <% if can? :destroy, @post %>
-    <%= button_to 'Delete Post', "/users/#{params[:user_id]}/posts/#{@post.id}",  data: { "turbo-method": :delete , "turbo-confirm": "Are you sure?" }, class: "btn text-dark btn-danger" %>
+    <%= button_to 'Delete Post', "/users/#{params[:user_id]}/posts/#{@post.id}",  method: :delete, class: "btn text-dark btn-danger" %>
   <% end %> 
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,13 +1,15 @@
 <div class='container mt-4'>
   <h1>Here are details of a user's post</h1>
-  <div class="card mt-3">
+  <div class="form-control shadow mt-3">
     <div class="mt-3">
-      <h4><%=@post.title%> by: <%=@post.author.name%></h4>
-      <span>Comments: <%=@post.comments_counter%>, Likes: <%=@post.likes_counter%></span>
+      <h4 class="text-primary"><%=@post.title%> by: <%=@post.author.name%></h4>
+      <span class="text-warning">Comments: <%=@post.comments_counter%>, Likes: <%=@post.likes_counter%></span>
     </div>
     <br>
-    <p><%=@post.text%></p>
+    <p class="text-info"><%=@post.text%></p>
   </div>
+
+  <%= button_to "Delete Post", user_post_path, method: :delete, class: " form-control mt-3 btn btn-outline-danger" %>    
 
   <div class= "card">
     <%@post.comments.each do |comment|%>
@@ -16,5 +18,5 @@
   </div>
    <% if can? :destroy, @post %>
     <%= button_to 'Delete Post', "/users/#{params[:user_id]}/posts/#{@post.id}",  method: :delete, class: "btn text-dark btn-danger" %>
-  <% end %> 
+  <% end %>   
 </div>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,5 +1,5 @@
 <div class="sections">
-    <%= image_tag (user.photo), height: '120', width: '120' %>
+    <%= image_tag("images.png", :alt => "rss feed", class: 'img-fluid rounded-start') %>
     <div class="users">
         <h1><%= link_to (user.name), user%></h1>
         <span>Number of posts: <%=user.posts_counter%></span>

--- a/config/database-old.yml
+++ b/config/database-old.yml
@@ -26,7 +26,7 @@ default: &default
 
 development:
   <<: *default
-  database: blog_app_development
+  database: blog_app_development-2
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,16 +17,13 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  username: postgres
-  password: Instant12.,
-  host: localhost
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:
   <<: *default
-  database: blog_app_development
+  database: blog_app_development-2
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,8 @@ Rails.application.routes.draw do
   # root "users#index"
   root to: "users#index"
   resources :users, only: [:index, :show] do
-    resources :posts, only: [:index, :show, :new] do
-      resources :comments, only: [:create]
+    resources :posts, only: [:index, :show, :new, :create, :destroy] do
+      resources :comments, only: [:create, :destroy]
       resources :likes, only: [:create]
     end   
   end

--- a/db/migrate/20220721155706_add_role_to_user.rb
+++ b/db/migrate/20220721155706_add_role_to_user.rb
@@ -1,0 +1,5 @@
+class AddRoleToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :role, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_19_130809) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_21_155706) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -61,6 +61,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_19_130809) do
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
     t.string "surname"
+    t.string "role"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/examples.txt
+++ b/spec/examples.txt
@@ -1,10 +1,10 @@
 example_id                                    | status | run_time        |
 --------------------------------------------- | ------ | --------------- |
-./spec/views/login_spec.rb[1:1]               | passed | 0.0082 seconds  |
-./spec/views/login_spec.rb[1:2]               | passed | 0.0092 seconds  |
-./spec/views/login_spec.rb[1:3]               | passed | 0.01315 seconds |
-./spec/views/login_spec.rb[1:4]               | passed | 0.03971 seconds |
-./spec/views/login_spec.rb[1:5]               | passed | 1.7 seconds     |
+./spec/views/login_spec.rb[1:1]               | passed | 0.00953 seconds |
+./spec/views/login_spec.rb[1:2]               | passed | 0.00948 seconds |
+./spec/views/login_spec.rb[1:3]               | passed | 0.01535 seconds |
+./spec/views/login_spec.rb[1:4]               | passed | 1.93 seconds    |
+./spec/views/login_spec.rb[1:5]               | passed | 0.0723 seconds  |
 ./spec/views/posts/posts_index_spec.rb[1:1]   | passed | 0.0233 seconds  |
 ./spec/views/posts/posts_index_spec.rb[1:2]   | passed | 0.02757 seconds |
 ./spec/views/posts/posts_index_spec.rb[1:3]   | passed | 0.02946 seconds |

--- a/spec/views/login_spec.rb
+++ b/spec/views/login_spec.rb
@@ -1,12 +1,11 @@
 require 'rails_helper'
-# require 'login_partial_spec.rb'
 
 RSpec.feature 'Login', type: :feature do
   before :each do
     User.create(name: 'Testing', posts_counter: 0, email: 'user@example.com', password: 'password',
                 confirmed_at: '2022-03-02 22:25:13.71382')
   end
-  # include login_partial
+
   it 'can enter a name and receive a greeting' do
     visit user_session_path
     expect(page).to have_content 'Log in'


### PR DESCRIPTION
### Changes in this PR:

- Installed CanCanCan.
- Added role column to the users table using migration.
- Used CanCanCan to allow a user to delete their post or a user with an admin role to delete post.
- Added the "Delete" button to the view to ensure that only authorized users could see it.
 - Used CanCanCan to allow a user to delete their comment or a user with an admin role to delete comment.
- Added the "Delete" button to the view to ensure that only authorized users could see it.